### PR TITLE
Remove 'a' from in front of 'probabilities'.

### DIFF
--- a/lecture7.tex
+++ b/lecture7.tex
@@ -58,7 +58,7 @@
 \begin{itemize}
 \item The {\bf Bernoulli distribution} arises as the result of a
   binary outcome
-\item Bernoulli random variables take (only) the values 1 and 0 with a
+\item Bernoulli random variables take (only) the values 1 and 0 with
   probabilities of (say) $p$ and $1-p$ respectively
 \item The PMF for a Bernoulli random variable $X$ is
   $$P(X = x) =  p^x (1 - p)^{1 - x}$$


### PR DESCRIPTION
Fix a sentence in lecture 7. The sentence should be

---

"Bernoulli random variables take values 1 and 0 with probabilities of p and (1 - p)"

---
